### PR TITLE
Update InvalidInputData to use StandardError

### DIFF
--- a/lib/pairwise.rb
+++ b/lib/pairwise.rb
@@ -15,7 +15,7 @@ require 'yaml'
 
 
 module Pairwise
-  class InvalidInputData < Exception; end
+  class InvalidInputData < StandardError; end
 
   VERSION = '0.2.2'
 


### PR DESCRIPTION
Ruby best practice is to inherit from StandardError over directly inheriting from the Exception class directly. This allows for methods which catch StandardError to safely catch errors without also catching high priority Exceptions like System Interrupts.